### PR TITLE
[fix/back] fix_.env.dev_연산자 사이 공백 삭제

### DIFF
--- a/backend/.env.dev
+++ b/backend/.env.dev
@@ -1,3 +1,3 @@
-DEBUG = 1
-SECRET_KEY = 'django-insecure-mp4m&^+r36$507ucoyibbown0(@%h@fxvjm%gtl@+4k6((w%cs'
-DJANGO_ALLOWED_HOSTS = localhost 127.0.0.1 [::1]
+DEBUG=1
+SECRET_KEY='django-insecure-mp4m&^+r36$507ucoyibbown0(@%h@fxvjm%gtl@+4k6((w%cs'
+DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]


### PR DESCRIPTION
lightsail에서 docker-compose up --build 시 .env.dev가 공백을 가졌다는 error를 확인